### PR TITLE
Added options and code to enable ssl and use a specific port.

### DIFF
--- a/config-sample.json
+++ b/config-sample.json
@@ -8,6 +8,9 @@
         "host": "irc.server.com",
         "channels": ["#channel1", "#channel2"],
         "nick": "standup"
+        "password": "password_for_nick", // If this key exists, the bot will try to identify with nickserv
+        "ssl": false,
+        "port": 6667 // 6697 for ssl
     },
     "log": {
         "console": true,

--- a/standup-irc.js
+++ b/standup-irc.js
@@ -74,7 +74,9 @@ if (config.pg.enabled) {
 
 // Global client
 irc_client = new irc.Client(config.irc.host, config.irc.nick, {
-    channels: config.irc.channels
+    channels: config.irc.channels,
+    port: config.irc.port,
+    secure: config.irc.ssl
 });
 
 // Connected to IRC server
@@ -84,6 +86,16 @@ irc_client.on('registered', function(message) {
     // Store the nickname assigned by the server
     config.irc.realNick = message.args[0];
     logger.info('Using nickname: ' + config.irc.realNick);
+
+});
+
+// Wait for message of the day and decide whether we want to register our nick.
+irc_client.addListener('motd', function (motd) {
+    logger.info('Seen MOTD');
+    if (config.irc.password) {
+        logger.info('Identifying with Nickserv');
+        irc_client.say('nickserv', 'identify ' + config.irc.password);
+    }
 
     // Check for additional channels and join
     if (pg_client) {


### PR DESCRIPTION
If the 'password' key exists in the irc settings section, the bot will attempt to use that password to register it's nick with nickserv.

Hack hack hack.
