### PR TITLE
Nixes the autodeploy stuff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,3 @@ notifications:
       - "irc.mozilla.org#standup"
     on_success: change
     on_failure: always
-deploy:
-  provider: heroku
-  api_key:
-    secure: YaSnbpygUzl1HCUR+jYlYsu/8fO7G1q3iA6dGiKPYIhsBWEaMBQYfghP8b6ab6+5ui+19Kn4XWqLRovgDqSKAmNTWJobuhIkWj9QWIW/SjhmbzgGY3ilsP4f4JEJtMo1gq9QID2YI580302vu+vJtO3oD4C2vf+OHoZrlrHCWAY=
-  app: rogerroger
-  on:
-    repo: mythmon/standup-irc


### PR DESCRIPTION
We're in the middle of a bunch of stuff and doing an auto-deploy would
be not great. So I'm disabling it for now.

r?