### PR TITLE
commands.bye is not a function

### DIFF
--- a/standup-irc.js
+++ b/standup-irc.js
@@ -133,7 +133,7 @@ irc_client.on('invite', function(channel, from) {
 irc_client.on('kick', function(channel, user, by) {
     if (user === config.irc.realNick) {
         logger.info('Kicked from ' + channel + ' by ' + by + '.');
-        commands.bye(user, channel);
+        commands.bye.func(user, channel);
     }
 });
 


### PR DESCRIPTION
Kicking the bot causes an uncaught exception (commands.bye is not a function).
This fixes the exception, but maybe we do not want to call `bye`: Bye says "bye" to the channel and leaves via /part. This is meaningless (but not harmful) when already kicked. Maybe we just want to do the latter part and remove the channel from the database?

I have caused the bot to crash by kicking it, now it won't come back. Maybe because I tried to invite it to a channel that the bot thought it was still in (`#hax` is still in the database. May need manual removal)