### PR TITLE
Remove random jar-jar binks reference

### DIFF
--- a/standup-irc.js
+++ b/standup-irc.js
@@ -432,15 +432,8 @@ var commands = {
                 let response = api.status.create(user, project, status);
 
                 response.once('ok', function(data) {
-                    let msg;
                     let user_url = `${config.standup.url}/user/${user}/`;
-
-                    if (Math.random() < 0.97) {
-                        msg = 'Ok, submitted ';
-                    } else {
-                        msg = 'Okeeday, meesa submittin ';
-                    }
-                    msg += 'status #' + data.id + ' for ' + user_url;
+                    let msg = `Ok, submitted #${data.id} for ${user_url}`;
                     utils.talkback(channel, user, msg);
                 });
 


### PR DESCRIPTION
I recognize the intention behind this is funny, but I think it's probably best to remove it.
The code is cleaner this way as well.