### PR TITLE
Add end-of-days message

### DIFF
--- a/standup-irc.js
+++ b/standup-irc.js
@@ -433,7 +433,7 @@ var commands = {
 
                 response.once('ok', function(data) {
                     let user_url = `${config.standup.url}/user/${user}/`;
-                    let msg = `Ok, submitted #${data.id} for ${user_url}`;
+                    let msg = `Ok, submitted #${data.id} for ${user_url} . FYI, Standups is shutting down. See website for details.`;
                     utils.talkback(channel, user, msg);
                 });
 


### PR DESCRIPTION
We're shutting down Standup and want to tell the users.

We can't do a standup broadcast because it sends too much data all at once
and the IRC server kicks the bot. That's covered in some issue somewhere.

So this changes the reply message figuring that all users who use it via
IRC will see the reply message. Then we don't trigger broadcast issues
and we don't have to hunt people down.